### PR TITLE
Make the code simple

### DIFF
--- a/src/main/java/dev/xdmeow/core/methods/impl/BigHandshake.java
+++ b/src/main/java/dev/xdmeow/core/methods/impl/BigHandshake.java
@@ -15,9 +15,7 @@ public class BigHandshake implements IMethod{
     private int size = 1024;
 
     public BigHandshake() {
-        for (int i = 1; i < this.size; i++) {
-            this.xd += String.valueOf(this.xd);
-        }
+            this.xd = this.xd.repeat(this.size); 
       }
 
       public void accept(Channel channel, Proxy proxy) {


### PR DESCRIPTION
Removed the unnecessary loop for generating the String and instead replaced it with built-in Java's `.repeat()` method.